### PR TITLE
Large variable missing

### DIFF
--- a/_objects.box.scss
+++ b/_objects.box.scss
@@ -18,6 +18,7 @@ $inuit-box-padding--huge:   quadruple($inuit-box-padding) !default;
 $inuit-enable-box--flush:   false !default;
 $inuit-enable-box--tiny:    false !default;
 $inuit-enable-box--small:   false !default;
+$inuit-enable-box--large:   false !default;
 $inuit-enable-box--huge:    false !default;
 
 


### PR DESCRIPTION
$inuit-enable-box--large:   false !default; is missing
