### PR TITLE
Fixes typo in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Harry Roberts <harry@csswizardry.com>"
   ],
   "description": "Basic box object for the inuitcss framework",
-  "main": "_base.tables.scss",
+  "main": "_objects.box.scss",
   "keywords": [
     "inuitcss",
     "oocss",


### PR DESCRIPTION
Automated tools (like `grunt-bower-install`) fail to discover the main file as the `main` member points to a file that doesn't exist or inject the wrong one.
